### PR TITLE
Fix content offset shift on prepend/append

### DIFF
--- a/Sources/MessagingUI/Tiled/TiledCollectionViewLayout.swift
+++ b/Sources/MessagingUI/Tiled/TiledCollectionViewLayout.swift
@@ -20,11 +20,7 @@ public final class TiledCollectionViewLayout: UICollectionViewLayout {
 
   /// Additional content inset to apply on top of the calculated inset.
   /// Use this to add extra space for keyboard, headers, footers, etc.
-  public var additionalContentInset: UIEdgeInsets = .zero {
-    didSet {
-      print(additionalContentInset)
-    }
-  }
+  public var additionalContentInset: UIEdgeInsets = .zero
 
   /// Size of the header supplementary view (loading indicator at top)
   public var headerSize: CGSize = .zero

--- a/Sources/MessagingUI/Tiled/TiledView.swift
+++ b/Sources/MessagingUI/Tiled/TiledView.swift
@@ -722,12 +722,13 @@ final class TiledUIView<
         return
       }
 
+      items.insert(contentsOf: newItems, at: 0)
+      tiledLayout.prependItems(count: newItems.count)
+
       let indexPaths = (0..<newItems.count).map { IndexPath(item: $0, section: 0) }
 
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
-          items.insert(contentsOf: newItems, at: 0)
-          tiledLayout.prependItems(count: newItems.count)
           collectionView.insertItems(at: indexPaths)
         }, completion: { _ in
           completion()
@@ -741,14 +742,15 @@ final class TiledUIView<
         return
       }
 
+      items.append(contentsOf: newItems)
+      tiledLayout.appendItems(count: newItems.count, startingIndex: startingIndex)
+
       let indexPaths = (startingIndex..<startingIndex + newItems.count).map {
         IndexPath(item: $0, section: 0)
       }
 
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
-          items.append(contentsOf: newItems)
-          tiledLayout.appendItems(count: newItems.count, startingIndex: startingIndex)
           collectionView.insertItems(at: indexPaths)
         }, completion: { [weak self] _ in
           guard let self else { return }
@@ -767,16 +769,17 @@ final class TiledUIView<
         return
       }
 
+      for (offset, item) in newItems.enumerated() {
+        items.insert(item, at: index + offset)
+      }
+      tiledLayout.insertItems(count: newItems.count, at: index)
+
       let indexPaths = (index..<index + newItems.count).map {
         IndexPath(item: $0, section: 0)
       }
 
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
-          for (offset, item) in newItems.enumerated() {
-            items.insert(item, at: index + offset)
-          }
-          tiledLayout.insertItems(count: newItems.count, at: index)
           collectionView.insertItems(at: indexPaths)
         }, completion: { _ in
           completion()
@@ -794,13 +797,14 @@ final class TiledUIView<
         return
       }
 
+      for item in newItems {
+        if let index = items.firstIndex(where: { $0.id == item.id }) {
+          items[index] = item
+        }
+      }
+
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
-          for item in newItems {
-            if let index = items.firstIndex(where: { $0.id == item.id }) {
-              items[index] = item
-            }
-          }
           collectionView.reconfigureItems(at: indexPaths)
         }, completion: { _ in
           completion()
@@ -818,12 +822,13 @@ final class TiledUIView<
         return
       }
 
+      items.removeAll { idsSet.contains($0.id) }
+      tiledLayout.removeItems(at: indicesToRemove)
+
       let indexPaths = indicesToRemove.map { IndexPath(item: $0, section: 0) }
 
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
-          items.removeAll { idsSet.contains($0.id) }
-          tiledLayout.removeItems(at: indicesToRemove)
           collectionView.deleteItems(at: indexPaths)
         }, completion: { _ in
           completion()


### PR DESCRIPTION
## Summary
- Move `items` and `tiledLayout` state mutations out of `performBatchUpdates` in `applyChange`, restoring the 1.6.0 ordering. Mutating the layout inside the batch update prevented `UICollectionView` from resolving correct before/after attributes, which caused visible content offset shifts when prepending or appending items.
- Remove a leftover `print(additionalContentInset)` debug statement on `TiledCollectionViewLayout.additionalContentInset.didSet`.

## Background
Reported as: content offset visibly jumps when items are prepended or appended on `main`, but not on `1.6.0`. The regression was introduced in #35 ("Make ListDataSource private"), where `prependItems` / `appendItems` / `insertItems` / `removeItems` calls on the layout were folded inside `performBatchUpdates`. Restoring the original ordering fixes the offset behavior.

## Test plan
- [x] `xcodebuild -scheme swiftui-messaging-ui -destination 'generic/platform=iOS Simulator' build` succeeds
- [x] Manual verification in `MessagingUIDevelopment` — prepend/append no longer shifts the visible content offset
- [ ] Re-check `ApplyDiffDemo` (replace/insert/update/remove paths)

🤖 Generated with [Claude Code](https://claude.com/claude-code)