### PR TITLE
Defer layout mutations to prepare(forCollectionViewUpdates:)

### DIFF
--- a/Sources/MessagingUI/Tiled/TiledCollectionViewLayout.swift
+++ b/Sources/MessagingUI/Tiled/TiledCollectionViewLayout.swift
@@ -52,6 +52,18 @@ public final class TiledCollectionViewLayout: UICollectionViewLayout {
   /// Tracks whether item heights need recalculation due to width being 0 at initial add time.
   private var needsHeightRecalculation: Bool = false
 
+  /// Pending structural update to apply inside `prepareForCollectionViewUpdates(_:)`.
+  /// Set from `TiledView` before `performBatchUpdates` so UIKit captures the "before"
+  /// layout state correctly before the layout transitions to the "after" state.
+  public enum PendingUpdate {
+    case prepend(count: Int)
+    case append(count: Int, startingIndex: Int)
+    case insert(count: Int, at: Int)
+    case remove(indices: [Int])
+  }
+
+  private var pendingUpdate: PendingUpdate?
+
   // MARK: - UICollectionViewLayout Overrides
 
   public override var collectionViewContentSize: CGSize {
@@ -336,6 +348,47 @@ public final class TiledCollectionViewLayout: UICollectionViewLayout {
     }
 
     return context
+  }
+
+  // MARK: - Batch Update Hooks
+
+  /// Enqueue the next structural change so it is applied inside
+  /// `prepareForCollectionViewUpdates(_:)`, after `UICollectionView` has
+  /// captured the "before" state for animation.
+  public func enqueuePendingUpdate(_ update: PendingUpdate) {
+    pendingUpdate = update
+  }
+
+  public override func prepare(forCollectionViewUpdates updateItems: [UICollectionViewUpdateItem]) {
+    super.prepare(forCollectionViewUpdates: updateItems)
+
+    guard let update = pendingUpdate else { return }
+    pendingUpdate = nil
+
+    switch update {
+    case .prepend(let count):
+      prependItems(count: count)
+    case .append(let count, let startingIndex):
+      appendItems(count: count, startingIndex: startingIndex)
+    case .insert(let count, let index):
+      insertItems(count: count, at: index)
+    case .remove(let indices):
+      removeItems(at: indices)
+    }
+
+    // Refresh contentInset now that item bounds have changed. `prepare()` is
+    // not guaranteed to run after `prepare(forCollectionViewUpdates:)`, so the
+    // inset would otherwise stay frozen at the pre-update value — making the
+    // newly added range unreachable by scrolling.
+    if let collectionView {
+      collectionView.contentInset = calculateContentInset()
+    }
+  }
+
+  public override func finalizeCollectionViewUpdates() {
+    super.finalizeCollectionViewUpdates()
+    // Defensive: in case a pending update was set but no batch was processed.
+    pendingUpdate = nil
   }
 
   // MARK: - Public Item Management API

--- a/Sources/MessagingUI/Tiled/TiledView.swift
+++ b/Sources/MessagingUI/Tiled/TiledView.swift
@@ -723,10 +723,10 @@ final class TiledUIView<
       }
 
       items.insert(contentsOf: newItems, at: 0)
-      tiledLayout.prependItems(count: newItems.count)
 
       let indexPaths = (0..<newItems.count).map { IndexPath(item: $0, section: 0) }
 
+      tiledLayout.enqueuePendingUpdate(.prepend(count: newItems.count))
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
           collectionView.insertItems(at: indexPaths)
@@ -743,12 +743,14 @@ final class TiledUIView<
       }
 
       items.append(contentsOf: newItems)
-      tiledLayout.appendItems(count: newItems.count, startingIndex: startingIndex)
 
       let indexPaths = (startingIndex..<startingIndex + newItems.count).map {
         IndexPath(item: $0, section: 0)
       }
 
+      tiledLayout.enqueuePendingUpdate(
+        .append(count: newItems.count, startingIndex: startingIndex)
+      )
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
           collectionView.insertItems(at: indexPaths)
@@ -772,12 +774,12 @@ final class TiledUIView<
       for (offset, item) in newItems.enumerated() {
         items.insert(item, at: index + offset)
       }
-      tiledLayout.insertItems(count: newItems.count, at: index)
 
       let indexPaths = (index..<index + newItems.count).map {
         IndexPath(item: $0, section: 0)
       }
 
+      tiledLayout.enqueuePendingUpdate(.insert(count: newItems.count, at: index))
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
           collectionView.insertItems(at: indexPaths)
@@ -823,10 +825,10 @@ final class TiledUIView<
       }
 
       items.removeAll { idsSet.contains($0.id) }
-      tiledLayout.removeItems(at: indicesToRemove)
 
       let indexPaths = indicesToRemove.map { IndexPath(item: $0, section: 0) }
 
+      tiledLayout.enqueuePendingUpdate(.remove(indices: indicesToRemove))
       UIView.performWithoutAnimation {
         collectionView.performBatchUpdates({
           collectionView.deleteItems(at: indexPaths)


### PR DESCRIPTION
## Summary
- Previously, `TiledView.applyChange` mutated `tiledLayout` (via `prependItems` / `appendItems` / `insertItems` / `removeItems`) **before** calling `performBatchUpdates`. `UICollectionView` was then capturing its "before" snapshot of the layout for animation while the layout had already advanced to the "after" state, which produced repeated `Received layout attributes with an invalid index path. Attributes will be ignored.` warnings during prepend/append/insert/remove.
- Introduce `TiledCollectionViewLayout.PendingUpdate` and apply structural changes from inside `prepare(forCollectionViewUpdates:)`, so UIKit captures the pre-update layout first and only then sees the post-update state when it queries `initialLayoutAttributesForAppearingItem` and `finalLayoutAttributesForDisappearingItem`.
- Refresh `contentInset` at the end of `prepare(forCollectionViewUpdates:)`. `prepare()` is not guaranteed to run after `prepare(forCollectionViewUpdates:)`, and without this refresh the inset stays frozen at the pre-update value, leaving the newly added range unreachable by scrolling.
- `finalizeCollectionViewUpdates` defensively clears any leftover pending update.
- `.replace` keeps direct layout mutation because it uses `reloadData()` and bypasses the batch-update path entirely.

## Known follow-up
- When the `prependLoader` finishes loading and its supplementary view shrinks to zero, `contentInset.top` changes by the loader height and `UIScrollView` clamps `contentOffset` to the new minimum, producing a small visible jump. This is structural to the current loader design (the loader lives inside the scrollable region as a header supplementary view) and not introduced by this PR — it just becomes more reliably observable now that the inset is refreshed deterministically inside the batch update.

## Test plan
- [x] `xcodebuild -scheme swiftui-messaging-ui -destination 'generic/platform=iOS Simulator' build` succeeds
- [x] Manual verification in `MessagingUIDevelopment`:
  - prepend no longer emits `Received layout attributes with an invalid index path` warnings
  - scrolling reaches the newly prepended range after a prepend
  - append / insert / remove animate without visual offset jump
- [ ] Re-check `ApplyDiffDemo` replace path (uses `reloadData`, should be unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)