### PR TITLE
[codex] Refine loading indicator edge behavior

### DIFF
--- a/Dev/MessagingUIDevelopment/TiledViewDemo.swift
+++ b/Dev/MessagingUIDevelopment/TiledViewDemo.swift
@@ -228,11 +228,12 @@ struct BookTiledView: View {
 
 // MARK: - Loading Indicator Demo
 
+/// Demonstrates manually controlled prepend and append loading indicators.
 struct BookTiledViewLoadingIndicator: View {
 
-  @State private var messages: [ChatMessage] = []
+  @State private var messages: [ChatMessage] = generateSampleMessages(count: 8, startId: 0)
   @State private var nextPrependId = -1
-  @State private var nextAppendId = 0
+  @State private var nextAppendId = 8
   @State private var scrollPosition = TiledScrollPosition()
   @State private var isPrependLoading = false
   @State private var isAppendLoading = false
@@ -274,63 +275,57 @@ struct BookTiledViewLoadingIndicator: View {
     .safeAreaInset(edge: .bottom) {
       VStack(spacing: 0) {
         Divider()
-        HStack {
-          Text("\(messages.count) items")
-            .font(.caption)
-            .foregroundStyle(.secondary)
-          Spacer()
-          HStack(spacing: 8) {
-            if isPrependLoading {
-              Text("Prepend...")
-                .font(.caption2)
-                .foregroundStyle(.orange)
+        VStack(spacing: 10) {
+          HStack {
+            Text("\(messages.count) items")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            Spacer()
+            HStack(spacing: 8) {
+              if isPrependLoading {
+                Text("Prepend")
+                  .font(.caption2)
+                  .foregroundStyle(.orange)
+              }
+              if isAppendLoading {
+                Text("Append")
+                  .font(.caption2)
+                  .foregroundStyle(.orange)
+              }
             }
-            if isAppendLoading {
-              Text("Append...")
-                .font(.caption2)
-                .foregroundStyle(.orange)
+          }
+
+          HStack(spacing: 12) {
+            Toggle(isOn: $isPrependLoading) {
+              Label("Prepend", systemImage: "arrow.up.circle")
             }
+            .toggleStyle(.button)
+
+            Toggle(isOn: $isAppendLoading) {
+              Label("Append", systemImage: "arrow.down.circle")
+            }
+            .toggleStyle(.button)
+
+            Spacer()
           }
         }
         .padding(.horizontal)
-        .padding(.vertical, 8)
+        .padding(.vertical, 10)
       }
       .background(.bar)
     }
     .toolbar {
       ToolbarItemGroup(placement: .bottomBar) {
-        // Toggle Prepend Loading
         Button {
-          isPrependLoading.toggle()
-          if isPrependLoading {
-            // Simulate loading and prepend after 2 seconds
-            Task {
-              try? await Task.sleep(for: .seconds(2))
-              let newMessages = generateSampleMessages(count: 5, startId: nextPrependId - 4)
-              messages.insert(contentsOf: newMessages, at: 0)
-              nextPrependId -= 5
-              isPrependLoading = false
-            }
-          }
+          prependMessages()
         } label: {
-          Label("Load Older", systemImage: isPrependLoading ? "hourglass" : "arrow.up.doc")
+          Label("Prepend 5", systemImage: "arrow.up.doc")
         }
 
-        // Toggle Append Loading
         Button {
-          isAppendLoading.toggle()
-          if isAppendLoading {
-            // Simulate loading and append after 2 seconds
-            Task {
-              try? await Task.sleep(for: .seconds(2))
-              let newMessages = generateSampleMessages(count: 5, startId: nextAppendId)
-              messages.append(contentsOf: newMessages)
-              nextAppendId += 5
-              isAppendLoading = false
-            }
-          }
+          appendMessages()
         } label: {
-          Label("Load Newer", systemImage: isAppendLoading ? "hourglass" : "arrow.down.doc")
+          Label("Append 5", systemImage: "arrow.down.doc")
         }
 
         Spacer()
@@ -352,18 +347,33 @@ struct BookTiledViewLoadingIndicator: View {
 
         // Reset
         Button {
-          nextPrependId = -1
-          nextAppendId = 5
-          isPrependLoading = false
-          isAppendLoading = false
-          let newItems = generateSampleMessages(count: 5, startId: 0)
-          messages = newItems
+          resetMessages()
         } label: {
           Image(systemName: "arrow.counterclockwise")
         }
       }
     }
     .navigationTitle("Loading Indicators")
+  }
+
+  private func prependMessages() {
+    let newMessages = generateSampleMessages(count: 5, startId: nextPrependId - 4)
+    messages.insert(contentsOf: newMessages, at: 0)
+    nextPrependId -= 5
+  }
+
+  private func appendMessages() {
+    let newMessages = generateSampleMessages(count: 5, startId: nextAppendId)
+    messages.append(contentsOf: newMessages)
+    nextAppendId += 5
+  }
+
+  private func resetMessages() {
+    nextPrependId = -1
+    nextAppendId = 8
+    isPrependLoading = false
+    isAppendLoading = false
+    messages = generateSampleMessages(count: 8, startId: 0)
   }
 }
 

--- a/Sources/MessagingUI/Animator/SpringAnimator.swift
+++ b/Sources/MessagingUI/Animator/SpringAnimator.swift
@@ -8,7 +8,7 @@
 import QuartzCore
 import SwiftUI
 
-/// A CADisplayLink-based animator that uses SwiftUI.Spring for smooth animations.
+/// A CADisplayLink-based animator that uses SwiftUI.Spring for spring-driven animations.
 /// This is a generic animator that doesn't depend on any specific UI component.
 @MainActor
 final class SpringAnimator {
@@ -74,8 +74,8 @@ final class SpringAnimator {
   // MARK: - Initialization
 
   /// Creates a new SpringAnimator with the specified spring configuration.
-  /// - Parameter spring: The spring to use for animation. Defaults to `.smooth`.
-  init(spring: Spring = .smooth) {
+  /// - Parameter spring: The spring to use for animation. Defaults to `.snappy`.
+  init(spring: Spring = .snappy) {
     self.spring = spring
   }
 

--- a/Sources/MessagingUI/Animator/SpringScrollAnimator.swift
+++ b/Sources/MessagingUI/Animator/SpringScrollAnimator.swift
@@ -68,8 +68,8 @@ final class SpringScrollAnimator {
   // MARK: - Initialization
 
   /// Creates a new SpringScrollAnimator with the specified spring configuration.
-  /// - Parameter spring: The spring to use for animation. Defaults to `.smooth`.
-  init(spring: Spring = .smooth) {
+  /// - Parameter spring: The spring to use for animation. Defaults to `.snappy`.
+  init(spring: Spring = .snappy) {
     self.animator = SpringAnimator(spring: spring)
   }
 

--- a/Sources/MessagingUI/Tiled/TiledView.swift
+++ b/Sources/MessagingUI/Tiled/TiledView.swift
@@ -44,6 +44,19 @@ fileprivate extension UIEdgeInsets {
       right: lhs.right - rhs.right
     )
   }
+
+  func interpolated(
+    to target: UIEdgeInsets,
+    progress: CGFloat
+  ) -> UIEdgeInsets {
+    let progress = min(max(progress, 0), 1)
+    return UIEdgeInsets(
+      top: top + (target.top - top) * progress,
+      left: left + (target.left - left) * progress,
+      bottom: bottom + (target.bottom - bottom) * progress,
+      right: right + (target.right - right) * progress
+    )
+  }
 }
 
 // MARK: - EdgeLoadTrigger
@@ -62,9 +75,6 @@ private struct EdgeLoadTrigger<Indicator: View>: ~Copyable {
 
   /// Whether the indicator is currently included in the visible content bounds.
   var isIndicatorVisible: Bool = false
-
-  /// Whether the indicator is being scrolled out before it leaves content bounds.
-  var isAnimatingIndicatorRemoval: Bool = false
 
   /// Generation token used to cancel deferred indicator presentation.
   var indicatorVisibilityGeneration: UInt = 0
@@ -403,8 +413,15 @@ final class TiledUIView<
   /// Scroll position tracking
   private var lastAppliedScrollVersion: UInt = 0
 
-  /// Spring animator for smooth scroll animations
+  /// Spring animator for programmatic scroll animations.
   private var springAnimator: SpringScrollAnimator?
+
+  /// Spring animator for edge content inset changes caused by hiding loaders.
+  private var hiddenEdgeContentInsetAnimator: SpringAnimator?
+  private var hiddenEdgeContentInsetAnimationGeneration: UInt = 0
+
+  /// Whether the current scroll movement was initiated by the user's pan gesture.
+  private var isUserScrollSessionActive: Bool = false
 
   /// True while the typing indicator is being scrolled out before removal.
   private var isAnimatingTypingIndicatorRemoval: Bool = false
@@ -953,9 +970,66 @@ final class TiledUIView<
     measureSize(for: displayItem, width: collectionView.bounds.width)?.height ?? 0
   }
 
-  private func updateHiddenEdgeContentInset() {
+  private func updateHiddenEdgeContentInset(animated: Bool = false) {
     guard collectionView != nil else { return }
 
+    setHiddenEdgeContentInset(
+      hiddenEdgeContentInset(),
+      animated: animated
+    )
+  }
+
+  private func setHiddenEdgeContentInset(
+    _ inset: UIEdgeInsets,
+    animated: Bool
+  ) {
+    guard tiledLayout.hiddenEdgeContentInset != inset else { return }
+
+    hiddenEdgeContentInsetAnimationGeneration &+= 1
+    let generation = hiddenEdgeContentInsetAnimationGeneration
+    hiddenEdgeContentInsetAnimator?.stop(finished: false)
+    hiddenEdgeContentInsetAnimator = nil
+
+    guard animated else {
+      tiledLayout.hiddenEdgeContentInset = inset
+      return
+    }
+
+    collectionView.layoutIfNeeded()
+    let startInset = tiledLayout.hiddenEdgeContentInset
+    let animator = SpringAnimator(
+      spring: Spring(duration: loadingIndicatorRemovalAnimationDuration, bounce: 0)
+    )
+    hiddenEdgeContentInsetAnimator = animator
+
+    // Animate the inset value frame-by-frame so UIScrollView receives each
+    // contentInset change and can apply its built-in contentOffset adjustment.
+    animator.animate(
+      from: 0,
+      to: 1,
+      onUpdate: { [weak self] progress in
+        guard let self else { return }
+        guard self.hiddenEdgeContentInsetAnimationGeneration == generation else { return }
+
+        self.tiledLayout.hiddenEdgeContentInset = startInset.interpolated(
+          to: inset,
+          progress: CGFloat(progress)
+        )
+        self.collectionView.layoutIfNeeded()
+      },
+      completion: { [weak self] _ in
+        guard let self else { return }
+        guard self.hiddenEdgeContentInsetAnimationGeneration == generation else { return }
+
+        self.hiddenEdgeContentInsetAnimator = nil
+        self.tiledLayout.hiddenEdgeContentInset = inset
+        self.collectionView.layoutIfNeeded()
+        self.clampContentOffsetToScrollableBounds(animated: false)
+      }
+    )
+  }
+
+  private func hiddenEdgeContentInset() -> UIEdgeInsets {
     let top: CGFloat
     if displayedAccessoryState.hasPrependLoader,
        !prependTrigger.shouldShowIndicator {
@@ -976,7 +1050,7 @@ final class TiledUIView<
       bottom += measuredAccessoryHeight(for: .typingIndicator)
     }
 
-    tiledLayout.hiddenEdgeContentInset = UIEdgeInsets(
+    return UIEdgeInsets(
       top: top,
       left: 0,
       bottom: bottom,
@@ -1337,14 +1411,20 @@ final class TiledUIView<
   // MARK: - UIScrollViewDelegate
 
   func scrollViewDidScroll(_ scrollView: UIScrollView) {
+    defer {
+      notifyScrollGeometry()
+    }
 
+    guard isUserScrollSessionActive else { return }
+
+    updateEdgeLoadTriggers(scrollView)
+  }
+
+  private func updateEdgeLoadTriggers(_ scrollView: UIScrollView) {
     // Prepend trigger
     let offsetY = scrollView.contentOffset.y + scrollView.contentInset.top
     if offsetY <= prependTrigger.threshold {
-      if !prependTrigger.isTriggered && !prependTrigger.isLoading {
-        prependTrigger.isTriggered = true
-        triggerPrependLoad()
-      }
+      triggerPrependLoadIfNeeded()
     } else {
       prependTrigger.isTriggered = false
     }
@@ -1360,8 +1440,24 @@ final class TiledUIView<
     } else {
       appendTrigger.isTriggered = false
     }
+  }
 
-    notifyScrollGeometry()
+  private func triggerPrependLoadIfNeeded() {
+    guard prependTrigger.loader != nil else { return }
+    guard !prependTrigger.isTriggered && !prependTrigger.isLoading else { return }
+
+    prependTrigger.isTriggered = true
+    triggerPrependLoad()
+  }
+
+  private func triggerPrependLoadForScrollToTop() {
+    guard prependTrigger.loader != nil else { return }
+    guard !prependTrigger.isLoading else { return }
+
+    // A status-bar tap is a fresh user intent even when the top-edge trigger is
+    // still latched from a previous top pass.
+    prependTrigger.isTriggered = true
+    triggerPrependLoad()
   }
 
   private func triggerPrependLoad() {
@@ -1380,14 +1476,9 @@ final class TiledUIView<
           guard let self else { return }
           guard self.prependTrigger.indicatorVisibilityGeneration == generation else { return }
           guard self.prependTrigger.isLoading else { return }
-          if self.prependTrigger.isAnimatingIndicatorRemoval {
-            self.springAnimator?.stop(finished: false)
-            self.springAnimator = nil
-          }
           self.prependTrigger.indicatorHideWorkItem?.cancel()
           self.prependTrigger.indicatorHideWorkItem = nil
           self.prependTrigger.pendingIndicatorHideGeneration = nil
-          self.prependTrigger.isAnimatingIndicatorRemoval = false
           self.prependTrigger.isIndicatorVisible = true
           self.updateLoadingIndicatorVisibility()
         }
@@ -1425,14 +1516,9 @@ final class TiledUIView<
           guard let self else { return }
           guard self.appendTrigger.indicatorVisibilityGeneration == generation else { return }
           guard self.appendTrigger.isLoading else { return }
-          if self.appendTrigger.isAnimatingIndicatorRemoval {
-            self.springAnimator?.stop(finished: false)
-            self.springAnimator = nil
-          }
           self.appendTrigger.indicatorHideWorkItem?.cancel()
           self.appendTrigger.indicatorHideWorkItem = nil
           self.appendTrigger.pendingIndicatorHideGeneration = nil
-          self.appendTrigger.isAnimatingIndicatorRemoval = false
           self.appendTrigger.isIndicatorVisible = true
           self.updateLoadingIndicatorVisibility()
         }
@@ -1454,12 +1540,27 @@ final class TiledUIView<
     }
   }
 
+  func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
+    isUserScrollSessionActive = false
+    triggerPrependLoadForScrollToTop()
+
+    return true
+  }
+
+  func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+    isUserScrollSessionActive = true
+  }
+
   func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
     hasDraggedIntoBottomSafeArea = false
+    if !decelerate {
+      isUserScrollSessionActive = false
+    }
   }
 
   func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
     hasDraggedIntoBottomSafeArea = false
+    isUserScrollSessionActive = false
   }
 
   private func notifyScrollGeometry() {
@@ -1597,6 +1698,7 @@ final class TiledUIView<
   }
   
   private func scrollTo(edge: TiledScrollPosition.Edge, animated: Bool) {
+    isUserScrollSessionActive = false
 
     collectionView.layoutIfNeeded()
 
@@ -1608,7 +1710,7 @@ final class TiledUIView<
     collectionView.setContentOffset(collectionView.contentOffset, animated: false)
 
     if animated {
-      let animator = SpringScrollAnimator(spring: .smooth)
+      let animator = SpringScrollAnimator()
       springAnimator = animator
 
       // Use dynamic target provider to adapt to contentInset changes mid-animation
@@ -1679,9 +1781,10 @@ final class TiledUIView<
   private func scrollToContentOffsetY(
     _ offsetY: CGFloat,
     animated: Bool,
-    spring: Spring = .smooth,
+    spring: Spring = .snappy,
     completion: (() -> Void)? = nil
   ) {
+    isUserScrollSessionActive = false
     springAnimator?.stop(finished: false)
     springAnimator = nil
     collectionView.setContentOffset(collectionView.contentOffset, animated: false)
@@ -1704,28 +1807,18 @@ final class TiledUIView<
   // MARK: - Loading Indicator Management
 
   private func resetPrependLoadingIndicatorVisibility() {
-    if prependTrigger.isAnimatingIndicatorRemoval {
-      springAnimator?.stop(finished: false)
-      springAnimator = nil
-    }
     prependTrigger.indicatorVisibilityGeneration &+= 1
     prependTrigger.indicatorHideWorkItem?.cancel()
     prependTrigger.indicatorHideWorkItem = nil
     prependTrigger.pendingIndicatorHideGeneration = nil
-    prependTrigger.isAnimatingIndicatorRemoval = false
     prependTrigger.isIndicatorVisible = false
   }
 
   private func resetAppendLoadingIndicatorVisibility() {
-    if appendTrigger.isAnimatingIndicatorRemoval {
-      springAnimator?.stop(finished: false)
-      springAnimator = nil
-    }
     appendTrigger.indicatorVisibilityGeneration &+= 1
     appendTrigger.indicatorHideWorkItem?.cancel()
     appendTrigger.indicatorHideWorkItem = nil
     appendTrigger.pendingIndicatorHideGeneration = nil
-    appendTrigger.isAnimatingIndicatorRemoval = false
     appendTrigger.isIndicatorVisible = false
   }
 
@@ -1733,14 +1826,9 @@ final class TiledUIView<
     guard prependTrigger.loader?.isProcessing != nil else { return }
 
     if prependTrigger.isLoading {
-      if prependTrigger.isAnimatingIndicatorRemoval {
-        springAnimator?.stop(finished: false)
-        springAnimator = nil
-      }
       prependTrigger.indicatorHideWorkItem?.cancel()
       prependTrigger.indicatorHideWorkItem = nil
       prependTrigger.pendingIndicatorHideGeneration = nil
-      prependTrigger.isAnimatingIndicatorRemoval = false
       prependTrigger.isIndicatorVisible = true
     } else if prependTrigger.isIndicatorVisible {
       requestPrependLoadingIndicatorHide(generation: prependTrigger.indicatorVisibilityGeneration)
@@ -1751,14 +1839,9 @@ final class TiledUIView<
     guard appendTrigger.loader?.isProcessing != nil else { return }
 
     if appendTrigger.isLoading {
-      if appendTrigger.isAnimatingIndicatorRemoval {
-        springAnimator?.stop(finished: false)
-        springAnimator = nil
-      }
       appendTrigger.indicatorHideWorkItem?.cancel()
       appendTrigger.indicatorHideWorkItem = nil
       appendTrigger.pendingIndicatorHideGeneration = nil
-      appendTrigger.isAnimatingIndicatorRemoval = false
       appendTrigger.isIndicatorVisible = true
     } else if appendTrigger.isIndicatorVisible {
       requestAppendLoadingIndicatorHide(generation: appendTrigger.indicatorVisibilityGeneration)
@@ -1808,31 +1891,27 @@ final class TiledUIView<
     guard !isApplyingItemChanges else { return }
     guard prependTrigger.pendingIndicatorHideGeneration == generation else { return }
     guard prependTrigger.indicatorVisibilityGeneration == generation else { return }
-    guard !prependTrigger.isAnimatingIndicatorRemoval else { return }
 
-    if animatePrependLoadingIndicatorRemovalIfNeeded(generation: generation) {
-      return
-    }
-
-    completePrependLoadingIndicatorHide(generation: generation, clampAnimated: true)
+    completePrependLoadingIndicatorHide(
+      generation: generation,
+      animatesHiddenEdgeContentInset: shouldAnimatePrependLoadingIndicatorRemoval()
+    )
   }
 
   private func finishAppendLoadingIndicatorHide(generation: UInt) {
     guard !isApplyingItemChanges else { return }
     guard appendTrigger.pendingIndicatorHideGeneration == generation else { return }
     guard appendTrigger.indicatorVisibilityGeneration == generation else { return }
-    guard !appendTrigger.isAnimatingIndicatorRemoval else { return }
 
-    if animateAppendLoadingIndicatorRemovalIfNeeded(generation: generation) {
-      return
-    }
-
-    completeAppendLoadingIndicatorHide(generation: generation, clampAnimated: true)
+    completeAppendLoadingIndicatorHide(
+      generation: generation,
+      animatesHiddenEdgeContentInset: shouldAnimateAppendLoadingIndicatorRemoval()
+    )
   }
 
   private func completePrependLoadingIndicatorHide(
     generation: UInt,
-    clampAnimated: Bool
+    animatesHiddenEdgeContentInset: Bool
   ) {
     guard prependTrigger.pendingIndicatorHideGeneration == generation else { return }
     guard prependTrigger.indicatorVisibilityGeneration == generation else { return }
@@ -1840,17 +1919,20 @@ final class TiledUIView<
     prependTrigger.indicatorHideWorkItem?.cancel()
     prependTrigger.indicatorHideWorkItem = nil
     prependTrigger.pendingIndicatorHideGeneration = nil
-    prependTrigger.isAnimatingIndicatorRemoval = false
     prependTrigger.indicatorVisibilityGeneration &+= 1
     prependTrigger.isIndicatorVisible = false
-    updateLoadingIndicatorVisibility()
-    collectionView.layoutIfNeeded()
-    clampContentOffsetToScrollableBounds(animated: clampAnimated)
+    updateLoadingIndicatorVisibility(
+      animatesHiddenEdgeContentInset: animatesHiddenEdgeContentInset
+    )
+    if !animatesHiddenEdgeContentInset {
+      collectionView.layoutIfNeeded()
+      clampContentOffsetToScrollableBounds(animated: false)
+    }
   }
 
   private func completeAppendLoadingIndicatorHide(
     generation: UInt,
-    clampAnimated: Bool
+    animatesHiddenEdgeContentInset: Bool
   ) {
     guard appendTrigger.pendingIndicatorHideGeneration == generation else { return }
     guard appendTrigger.indicatorVisibilityGeneration == generation else { return }
@@ -1858,15 +1940,18 @@ final class TiledUIView<
     appendTrigger.indicatorHideWorkItem?.cancel()
     appendTrigger.indicatorHideWorkItem = nil
     appendTrigger.pendingIndicatorHideGeneration = nil
-    appendTrigger.isAnimatingIndicatorRemoval = false
     appendTrigger.indicatorVisibilityGeneration &+= 1
     appendTrigger.isIndicatorVisible = false
-    updateLoadingIndicatorVisibility()
-    collectionView.layoutIfNeeded()
-    clampContentOffsetToScrollableBounds(animated: clampAnimated)
+    updateLoadingIndicatorVisibility(
+      animatesHiddenEdgeContentInset: animatesHiddenEdgeContentInset
+    )
+    if !animatesHiddenEdgeContentInset {
+      collectionView.layoutIfNeeded()
+      clampContentOffsetToScrollableBounds(animated: false)
+    }
   }
 
-  private func animatePrependLoadingIndicatorRemovalIfNeeded(generation: UInt) -> Bool {
+  private func shouldAnimatePrependLoadingIndicatorRemoval() -> Bool {
     guard let attributes = layoutAttributesForAccessoryDisplayItem(.prependLoader),
           attributes.frame.height > 0 else {
       return false
@@ -1877,24 +1962,10 @@ final class TiledUIView<
       scrollableBounds.max,
       scrollableBounds.min + attributes.frame.height
     )
-    guard collectionView.contentOffset.y < targetOffsetY - 0.5 else { return false }
-
-    prependTrigger.isAnimatingIndicatorRemoval = true
-    schedulePrependLoadingIndicatorRemovalCompletion(generation: generation)
-    scrollToContentOffsetY(
-      targetOffsetY,
-      animated: true,
-      spring: Spring(duration: loadingIndicatorRemovalAnimationDuration, bounce: 0)
-    ) { [weak self] in
-      self?.completePrependLoadingIndicatorHide(
-        generation: generation,
-        clampAnimated: false
-      )
-    }
-    return true
+    return collectionView.contentOffset.y < targetOffsetY - 0.5
   }
 
-  private func animateAppendLoadingIndicatorRemovalIfNeeded(generation: UInt) -> Bool {
+  private func shouldAnimateAppendLoadingIndicatorRemoval() -> Bool {
     guard let attributes = layoutAttributesForAccessoryDisplayItem(.appendLoader),
           attributes.frame.height > 0 else {
       return false
@@ -1905,53 +1976,7 @@ final class TiledUIView<
       scrollableBounds.min,
       scrollableBounds.max - attributes.frame.height
     )
-    guard collectionView.contentOffset.y > targetOffsetY + 0.5 else { return false }
-
-    appendTrigger.isAnimatingIndicatorRemoval = true
-    scheduleAppendLoadingIndicatorRemovalCompletion(generation: generation)
-    scrollToContentOffsetY(
-      targetOffsetY,
-      animated: true,
-      spring: Spring(duration: loadingIndicatorRemovalAnimationDuration, bounce: 0)
-    ) { [weak self] in
-      self?.completeAppendLoadingIndicatorHide(
-        generation: generation,
-        clampAnimated: false
-      )
-    }
-    return true
-  }
-
-  private func schedulePrependLoadingIndicatorRemovalCompletion(generation: UInt) {
-    prependTrigger.indicatorHideWorkItem?.cancel()
-
-    let workItem = DispatchWorkItem { [weak self] in
-      self?.completePrependLoadingIndicatorHide(
-        generation: generation,
-        clampAnimated: false
-      )
-    }
-    prependTrigger.indicatorHideWorkItem = workItem
-    DispatchQueue.main.asyncAfter(
-      deadline: .now() + loadingIndicatorRemovalAnimationDuration,
-      execute: workItem
-    )
-  }
-
-  private func scheduleAppendLoadingIndicatorRemovalCompletion(generation: UInt) {
-    appendTrigger.indicatorHideWorkItem?.cancel()
-
-    let workItem = DispatchWorkItem { [weak self] in
-      self?.completeAppendLoadingIndicatorHide(
-        generation: generation,
-        clampAnimated: false
-      )
-    }
-    appendTrigger.indicatorHideWorkItem = workItem
-    DispatchQueue.main.asyncAfter(
-      deadline: .now() + loadingIndicatorRemovalAnimationDuration,
-      execute: workItem
-    )
+    return collectionView.contentOffset.y > targetOffsetY + 0.5
   }
 
   private func layoutAttributesForAccessoryDisplayItem(
@@ -1967,7 +1992,9 @@ final class TiledUIView<
     return attributes
   }
 
-  private func updateLoadingIndicatorVisibility() {
+  private func updateLoadingIndicatorVisibility(
+    animatesHiddenEdgeContentInset: Bool = false
+  ) {
     guard collectionView != nil else { return }
 
     setAccessoryDisplayItem(
@@ -1978,7 +2005,6 @@ final class TiledUIView<
         guard let self else { return }
         self.reconfigureAccessoryDisplayItem(.prependLoader)
         self.remeasureAccessoryDisplayItem(.prependLoader, positionPreservation: .itemsAfterMutation)
-        self.updateHiddenEdgeContentInset()
 
         self.setAccessoryDisplayItem(
           .appendLoader,
@@ -1988,7 +2014,7 @@ final class TiledUIView<
             guard let self else { return }
             self.reconfigureAccessoryDisplayItem(.appendLoader)
             self.remeasureAccessoryDisplayItem(.appendLoader, positionPreservation: .itemsBeforeMutation)
-            self.updateHiddenEdgeContentInset()
+            self.updateHiddenEdgeContentInset(animated: animatesHiddenEdgeContentInset)
           }
         )
       }

--- a/Sources/MessagingUI/Tiled/TiledView.swift
+++ b/Sources/MessagingUI/Tiled/TiledView.swift
@@ -105,6 +105,15 @@ private struct EdgeLoadTrigger<Indicator: View>: ~Copyable {
   }
 }
 
+/// Describes why prepend loading is being requested.
+private enum PrependLoadTriggerSource {
+  /// The user has scrolled near the top edge through the normal scroll path.
+  case edgeThreshold
+
+  /// The user tapped the status bar and UIKit is about to scroll to the top.
+  case scrollToTop
+}
+
 /// MARK: - RevealGestureState
 
 /// Encapsulates state for swipe-to-reveal gesture handling.
@@ -418,10 +427,17 @@ final class TiledUIView<
 
   /// Spring animator for edge content inset changes caused by hiding loaders.
   private var hiddenEdgeContentInsetAnimator: SpringAnimator?
+  private var hiddenEdgeContentInsetAnimationTarget: UIEdgeInsets?
   private var hiddenEdgeContentInsetAnimationGeneration: UInt = 0
 
   /// Whether the current scroll movement was initiated by the user's pan gesture.
   private var isUserScrollSessionActive: Bool = false
+
+  /// Whether a status-bar scroll-to-top request is waiting for prepend loading to settle.
+  private var isPrependLoadRequestedByScrollToTop: Bool = false
+
+  /// Whether the pending status-bar request has observed the external loading state.
+  private var hasScrollToTopPrependLoadObservedProcessing: Bool = false
 
   /// True while the typing indicator is being scrolled out before removal.
   private var isAnimatingTypingIndicatorRemoval: Bool = false
@@ -983,12 +999,18 @@ final class TiledUIView<
     _ inset: UIEdgeInsets,
     animated: Bool
   ) {
-    guard tiledLayout.hiddenEdgeContentInset != inset else { return }
+    if hiddenEdgeContentInsetAnimationTarget == inset {
+      return
+    }
+    guard hiddenEdgeContentInsetAnimator != nil || tiledLayout.hiddenEdgeContentInset != inset else { return }
 
     hiddenEdgeContentInsetAnimationGeneration &+= 1
     let generation = hiddenEdgeContentInsetAnimationGeneration
     hiddenEdgeContentInsetAnimator?.stop(finished: false)
     hiddenEdgeContentInsetAnimator = nil
+    hiddenEdgeContentInsetAnimationTarget = nil
+
+    guard tiledLayout.hiddenEdgeContentInset != inset else { return }
 
     guard animated else {
       tiledLayout.hiddenEdgeContentInset = inset
@@ -1001,6 +1023,7 @@ final class TiledUIView<
       spring: Spring(duration: loadingIndicatorRemovalAnimationDuration, bounce: 0)
     )
     hiddenEdgeContentInsetAnimator = animator
+    hiddenEdgeContentInsetAnimationTarget = inset
 
     // Animate the inset value frame-by-frame so UIScrollView receives each
     // contentInset change and can apply its built-in contentOffset adjustment.
@@ -1022,6 +1045,7 @@ final class TiledUIView<
         guard self.hiddenEdgeContentInsetAnimationGeneration == generation else { return }
 
         self.hiddenEdgeContentInsetAnimator = nil
+        self.hiddenEdgeContentInsetAnimationTarget = nil
         self.tiledLayout.hiddenEdgeContentInset = inset
         self.collectionView.layoutIfNeeded()
         self.clampContentOffsetToScrollableBounds(animated: false)
@@ -1424,7 +1448,7 @@ final class TiledUIView<
     // Prepend trigger
     let offsetY = scrollView.contentOffset.y + scrollView.contentInset.top
     if offsetY <= prependTrigger.threshold {
-      triggerPrependLoadIfNeeded()
+      triggerPrependLoadIfNeeded(source: .edgeThreshold)
     } else {
       prependTrigger.isTriggered = false
     }
@@ -1442,20 +1466,22 @@ final class TiledUIView<
     }
   }
 
-  private func triggerPrependLoadIfNeeded() {
-    guard prependTrigger.loader != nil else { return }
-    guard !prependTrigger.isTriggered && !prependTrigger.isLoading else { return }
-
-    prependTrigger.isTriggered = true
-    triggerPrependLoad()
-  }
-
-  private func triggerPrependLoadForScrollToTop() {
+  private func triggerPrependLoadIfNeeded(source: PrependLoadTriggerSource) {
     guard prependTrigger.loader != nil else { return }
     guard !prependTrigger.isLoading else { return }
 
-    // A status-bar tap is a fresh user intent even when the top-edge trigger is
-    // still latched from a previous top pass.
+    switch source {
+    case .edgeThreshold:
+      guard !prependTrigger.isTriggered else { return }
+    case .scrollToTop:
+      // A status-bar tap is a fresh user intent even when the top-edge trigger
+      // is still latched, but it still needs its own in-flight guard until the
+      // loader reports completion.
+      guard !isPrependLoadRequestedByScrollToTop else { return }
+      isPrependLoadRequestedByScrollToTop = true
+      hasScrollToTopPrependLoadObservedProcessing = false
+    }
+
     prependTrigger.isTriggered = true
     triggerPrependLoad()
   }
@@ -1485,6 +1511,8 @@ final class TiledUIView<
         defer {
           if let self {
             self.prependTrigger.task = nil
+            self.isPrependLoadRequestedByScrollToTop = false
+            self.hasScrollToTopPrependLoadObservedProcessing = false
             DispatchQueue.main.async { [weak self] in
               guard let self else { return }
               guard self.prependTrigger.indicatorVisibilityGeneration == generation else { return }
@@ -1542,7 +1570,7 @@ final class TiledUIView<
 
   func scrollViewShouldScrollToTop(_ scrollView: UIScrollView) -> Bool {
     isUserScrollSessionActive = false
-    triggerPrependLoadForScrollToTop()
+    triggerPrependLoadIfNeeded(source: .scrollToTop)
 
     return true
   }
@@ -1812,6 +1840,8 @@ final class TiledUIView<
     prependTrigger.indicatorHideWorkItem = nil
     prependTrigger.pendingIndicatorHideGeneration = nil
     prependTrigger.isIndicatorVisible = false
+    isPrependLoadRequestedByScrollToTop = false
+    hasScrollToTopPrependLoadObservedProcessing = false
   }
 
   private func resetAppendLoadingIndicatorVisibility() {
@@ -1826,12 +1856,21 @@ final class TiledUIView<
     guard prependTrigger.loader?.isProcessing != nil else { return }
 
     if prependTrigger.isLoading {
+      if isPrependLoadRequestedByScrollToTop {
+        hasScrollToTopPrependLoadObservedProcessing = true
+      }
       prependTrigger.indicatorHideWorkItem?.cancel()
       prependTrigger.indicatorHideWorkItem = nil
       prependTrigger.pendingIndicatorHideGeneration = nil
       prependTrigger.isIndicatorVisible = true
-    } else if prependTrigger.isIndicatorVisible {
-      requestPrependLoadingIndicatorHide(generation: prependTrigger.indicatorVisibilityGeneration)
+    } else {
+      if hasScrollToTopPrependLoadObservedProcessing {
+        isPrependLoadRequestedByScrollToTop = false
+        hasScrollToTopPrependLoadObservedProcessing = false
+      }
+      if prependTrigger.isIndicatorVisible {
+        requestPrependLoadingIndicatorHide(generation: prependTrigger.indicatorVisibilityGeneration)
+      }
     }
   }
 

--- a/Sources/MessagingUI/Tiled/TiledView.swift
+++ b/Sources/MessagingUI/Tiled/TiledView.swift
@@ -63,6 +63,9 @@ private struct EdgeLoadTrigger<Indicator: View>: ~Copyable {
   /// Whether the indicator is currently included in the visible content bounds.
   var isIndicatorVisible: Bool = false
 
+  /// Whether the indicator is being scrolled out before it leaves content bounds.
+  var isAnimatingIndicatorRemoval: Bool = false
+
   /// Generation token used to cancel deferred indicator presentation.
   var indicatorVisibilityGeneration: UInt = 0
 
@@ -395,6 +398,7 @@ final class TiledUIView<
   private var prependTrigger = EdgeLoadTrigger<PrependLoadingView>()
   private var appendTrigger = EdgeLoadTrigger<AppendLoadingView>()
   private let loadingIndicatorHideDelay: TimeInterval = 0.12
+  private let loadingIndicatorRemovalAnimationDuration: TimeInterval = 0.55
 
   /// Scroll position tracking
   private var lastAppliedScrollVersion: UInt = 0
@@ -1376,9 +1380,14 @@ final class TiledUIView<
           guard let self else { return }
           guard self.prependTrigger.indicatorVisibilityGeneration == generation else { return }
           guard self.prependTrigger.isLoading else { return }
+          if self.prependTrigger.isAnimatingIndicatorRemoval {
+            self.springAnimator?.stop(finished: false)
+            self.springAnimator = nil
+          }
           self.prependTrigger.indicatorHideWorkItem?.cancel()
           self.prependTrigger.indicatorHideWorkItem = nil
           self.prependTrigger.pendingIndicatorHideGeneration = nil
+          self.prependTrigger.isAnimatingIndicatorRemoval = false
           self.prependTrigger.isIndicatorVisible = true
           self.updateLoadingIndicatorVisibility()
         }
@@ -1416,9 +1425,14 @@ final class TiledUIView<
           guard let self else { return }
           guard self.appendTrigger.indicatorVisibilityGeneration == generation else { return }
           guard self.appendTrigger.isLoading else { return }
+          if self.appendTrigger.isAnimatingIndicatorRemoval {
+            self.springAnimator?.stop(finished: false)
+            self.springAnimator = nil
+          }
           self.appendTrigger.indicatorHideWorkItem?.cancel()
           self.appendTrigger.indicatorHideWorkItem = nil
           self.appendTrigger.pendingIndicatorHideGeneration = nil
+          self.appendTrigger.isAnimatingIndicatorRemoval = false
           self.appendTrigger.isIndicatorVisible = true
           self.updateLoadingIndicatorVisibility()
         }
@@ -1690,18 +1704,28 @@ final class TiledUIView<
   // MARK: - Loading Indicator Management
 
   private func resetPrependLoadingIndicatorVisibility() {
+    if prependTrigger.isAnimatingIndicatorRemoval {
+      springAnimator?.stop(finished: false)
+      springAnimator = nil
+    }
     prependTrigger.indicatorVisibilityGeneration &+= 1
     prependTrigger.indicatorHideWorkItem?.cancel()
     prependTrigger.indicatorHideWorkItem = nil
     prependTrigger.pendingIndicatorHideGeneration = nil
+    prependTrigger.isAnimatingIndicatorRemoval = false
     prependTrigger.isIndicatorVisible = false
   }
 
   private func resetAppendLoadingIndicatorVisibility() {
+    if appendTrigger.isAnimatingIndicatorRemoval {
+      springAnimator?.stop(finished: false)
+      springAnimator = nil
+    }
     appendTrigger.indicatorVisibilityGeneration &+= 1
     appendTrigger.indicatorHideWorkItem?.cancel()
     appendTrigger.indicatorHideWorkItem = nil
     appendTrigger.pendingIndicatorHideGeneration = nil
+    appendTrigger.isAnimatingIndicatorRemoval = false
     appendTrigger.isIndicatorVisible = false
   }
 
@@ -1709,9 +1733,14 @@ final class TiledUIView<
     guard prependTrigger.loader?.isProcessing != nil else { return }
 
     if prependTrigger.isLoading {
+      if prependTrigger.isAnimatingIndicatorRemoval {
+        springAnimator?.stop(finished: false)
+        springAnimator = nil
+      }
       prependTrigger.indicatorHideWorkItem?.cancel()
       prependTrigger.indicatorHideWorkItem = nil
       prependTrigger.pendingIndicatorHideGeneration = nil
+      prependTrigger.isAnimatingIndicatorRemoval = false
       prependTrigger.isIndicatorVisible = true
     } else if prependTrigger.isIndicatorVisible {
       requestPrependLoadingIndicatorHide(generation: prependTrigger.indicatorVisibilityGeneration)
@@ -1722,9 +1751,14 @@ final class TiledUIView<
     guard appendTrigger.loader?.isProcessing != nil else { return }
 
     if appendTrigger.isLoading {
+      if appendTrigger.isAnimatingIndicatorRemoval {
+        springAnimator?.stop(finished: false)
+        springAnimator = nil
+      }
       appendTrigger.indicatorHideWorkItem?.cancel()
       appendTrigger.indicatorHideWorkItem = nil
       appendTrigger.pendingIndicatorHideGeneration = nil
+      appendTrigger.isAnimatingIndicatorRemoval = false
       appendTrigger.isIndicatorVisible = true
     } else if appendTrigger.isIndicatorVisible {
       requestAppendLoadingIndicatorHide(generation: appendTrigger.indicatorVisibilityGeneration)
@@ -1774,26 +1808,163 @@ final class TiledUIView<
     guard !isApplyingItemChanges else { return }
     guard prependTrigger.pendingIndicatorHideGeneration == generation else { return }
     guard prependTrigger.indicatorVisibilityGeneration == generation else { return }
+    guard !prependTrigger.isAnimatingIndicatorRemoval else { return }
 
-    prependTrigger.indicatorHideWorkItem?.cancel()
-    prependTrigger.indicatorHideWorkItem = nil
-    prependTrigger.pendingIndicatorHideGeneration = nil
-    prependTrigger.indicatorVisibilityGeneration &+= 1
-    prependTrigger.isIndicatorVisible = false
-    updateLoadingIndicatorVisibility()
+    if animatePrependLoadingIndicatorRemovalIfNeeded(generation: generation) {
+      return
+    }
+
+    completePrependLoadingIndicatorHide(generation: generation, clampAnimated: true)
   }
 
   private func finishAppendLoadingIndicatorHide(generation: UInt) {
     guard !isApplyingItemChanges else { return }
     guard appendTrigger.pendingIndicatorHideGeneration == generation else { return }
     guard appendTrigger.indicatorVisibilityGeneration == generation else { return }
+    guard !appendTrigger.isAnimatingIndicatorRemoval else { return }
+
+    if animateAppendLoadingIndicatorRemovalIfNeeded(generation: generation) {
+      return
+    }
+
+    completeAppendLoadingIndicatorHide(generation: generation, clampAnimated: true)
+  }
+
+  private func completePrependLoadingIndicatorHide(
+    generation: UInt,
+    clampAnimated: Bool
+  ) {
+    guard prependTrigger.pendingIndicatorHideGeneration == generation else { return }
+    guard prependTrigger.indicatorVisibilityGeneration == generation else { return }
+
+    prependTrigger.indicatorHideWorkItem?.cancel()
+    prependTrigger.indicatorHideWorkItem = nil
+    prependTrigger.pendingIndicatorHideGeneration = nil
+    prependTrigger.isAnimatingIndicatorRemoval = false
+    prependTrigger.indicatorVisibilityGeneration &+= 1
+    prependTrigger.isIndicatorVisible = false
+    updateLoadingIndicatorVisibility()
+    collectionView.layoutIfNeeded()
+    clampContentOffsetToScrollableBounds(animated: clampAnimated)
+  }
+
+  private func completeAppendLoadingIndicatorHide(
+    generation: UInt,
+    clampAnimated: Bool
+  ) {
+    guard appendTrigger.pendingIndicatorHideGeneration == generation else { return }
+    guard appendTrigger.indicatorVisibilityGeneration == generation else { return }
 
     appendTrigger.indicatorHideWorkItem?.cancel()
     appendTrigger.indicatorHideWorkItem = nil
     appendTrigger.pendingIndicatorHideGeneration = nil
+    appendTrigger.isAnimatingIndicatorRemoval = false
     appendTrigger.indicatorVisibilityGeneration &+= 1
     appendTrigger.isIndicatorVisible = false
     updateLoadingIndicatorVisibility()
+    collectionView.layoutIfNeeded()
+    clampContentOffsetToScrollableBounds(animated: clampAnimated)
+  }
+
+  private func animatePrependLoadingIndicatorRemovalIfNeeded(generation: UInt) -> Bool {
+    guard let attributes = layoutAttributesForAccessoryDisplayItem(.prependLoader),
+          attributes.frame.height > 0 else {
+      return false
+    }
+
+    let scrollableBounds = scrollableContentOffsetBounds()
+    let targetOffsetY = min(
+      scrollableBounds.max,
+      scrollableBounds.min + attributes.frame.height
+    )
+    guard collectionView.contentOffset.y < targetOffsetY - 0.5 else { return false }
+
+    prependTrigger.isAnimatingIndicatorRemoval = true
+    schedulePrependLoadingIndicatorRemovalCompletion(generation: generation)
+    scrollToContentOffsetY(
+      targetOffsetY,
+      animated: true,
+      spring: Spring(duration: loadingIndicatorRemovalAnimationDuration, bounce: 0)
+    ) { [weak self] in
+      self?.completePrependLoadingIndicatorHide(
+        generation: generation,
+        clampAnimated: false
+      )
+    }
+    return true
+  }
+
+  private func animateAppendLoadingIndicatorRemovalIfNeeded(generation: UInt) -> Bool {
+    guard let attributes = layoutAttributesForAccessoryDisplayItem(.appendLoader),
+          attributes.frame.height > 0 else {
+      return false
+    }
+
+    let scrollableBounds = scrollableContentOffsetBounds()
+    let targetOffsetY = max(
+      scrollableBounds.min,
+      scrollableBounds.max - attributes.frame.height
+    )
+    guard collectionView.contentOffset.y > targetOffsetY + 0.5 else { return false }
+
+    appendTrigger.isAnimatingIndicatorRemoval = true
+    scheduleAppendLoadingIndicatorRemovalCompletion(generation: generation)
+    scrollToContentOffsetY(
+      targetOffsetY,
+      animated: true,
+      spring: Spring(duration: loadingIndicatorRemovalAnimationDuration, bounce: 0)
+    ) { [weak self] in
+      self?.completeAppendLoadingIndicatorHide(
+        generation: generation,
+        clampAnimated: false
+      )
+    }
+    return true
+  }
+
+  private func schedulePrependLoadingIndicatorRemovalCompletion(generation: UInt) {
+    prependTrigger.indicatorHideWorkItem?.cancel()
+
+    let workItem = DispatchWorkItem { [weak self] in
+      self?.completePrependLoadingIndicatorHide(
+        generation: generation,
+        clampAnimated: false
+      )
+    }
+    prependTrigger.indicatorHideWorkItem = workItem
+    DispatchQueue.main.asyncAfter(
+      deadline: .now() + loadingIndicatorRemovalAnimationDuration,
+      execute: workItem
+    )
+  }
+
+  private func scheduleAppendLoadingIndicatorRemovalCompletion(generation: UInt) {
+    appendTrigger.indicatorHideWorkItem?.cancel()
+
+    let workItem = DispatchWorkItem { [weak self] in
+      self?.completeAppendLoadingIndicatorHide(
+        generation: generation,
+        clampAnimated: false
+      )
+    }
+    appendTrigger.indicatorHideWorkItem = workItem
+    DispatchQueue.main.asyncAfter(
+      deadline: .now() + loadingIndicatorRemovalAnimationDuration,
+      execute: workItem
+    )
+  }
+
+  private func layoutAttributesForAccessoryDisplayItem(
+    _ displayItem: AccessoryDisplayItem
+  ) -> UICollectionViewLayoutAttributes? {
+    collectionView.layoutIfNeeded()
+
+    guard let indexPath = indexPath(for: displayItem),
+          let attributes = tiledLayout.layoutAttributesForItem(at: indexPath) else {
+      return nil
+    }
+
+    return attributes
   }
 
   private func updateLoadingIndicatorVisibility() {


### PR DESCRIPTION
## Summary

- Add a Loading Indicator demo path that can toggle prepend and append loader visibility directly.
- Animate loader dismissal by interpolating `hiddenEdgeContentInset` instead of driving `contentOffset` manually.
- Gate edge loading to user-driven scroll sessions, while preserving status-bar scroll-to-top as an explicit prepend trigger.
- Make prepend trigger source explicit and guard status-bar sync loader re-entry until external loading state settles.
- Track the active hidden-edge inset animation target so layout resyncs do not accidentally cancel or continue stale animations.

## Why

The loading indicator could disappear without an animation when no new content was inserted, which made the content offset appear to jump. Programmatic scrolls such as initial scroll-to-bottom could also trigger edge loaders unintentionally. The status-bar scroll-to-top path needed its own intent signal, but bypassing the normal edge latch introduced a small sync-loader re-entry risk.

## Validation

- `git diff --check`
- `xcodebuild -scheme swiftui-messaging-ui -destination 'platform=iOS Simulator,id=05718949-3329-4852-9F7A-FA1649441821' build`
