### PR TITLE
[codex] Suppress self-sizing invalidation during affected batch updates

### DIFF
--- a/Sources/MessagingUI/Tiled/TiledCollectionViewLayout.swift
+++ b/Sources/MessagingUI/Tiled/TiledCollectionViewLayout.swift
@@ -199,7 +199,25 @@ public final class TiledCollectionViewLayout: UICollectionViewLayout {
     forPreferredLayoutAttributes preferredAttributes: UICollectionViewLayoutAttributes,
     withOriginalAttributes originalAttributes: UICollectionViewLayoutAttributes
   ) -> Bool {
-    preferredAttributes.frame.size.height != originalAttributes.frame.size.height
+    guard !shouldSuppressSelfSizingInvalidationDuringBatchUpdates else { return false }
+    return preferredAttributes.frame.size.height != originalAttributes.frame.size.height
+  }
+
+  /// Returns whether preferred-size invalidation should be blocked while UIKit
+  /// is resolving a collection-view batch update.
+  private var shouldSuppressSelfSizingInvalidationDuringBatchUpdates: Bool {
+    guard batchUpdateMetrics != nil else { return false }
+
+    // UIKit can ask visible cells from both pre-update and post-update
+    // snapshots for preferred sizes while a batch update is resolving on
+    // affected OS versions. Starting another self-sizing invalidation in that
+    // window can recurse through visible-cell updates before either snapshot
+    // settles. iOS 26 and newer keep the default self-sizing behavior.
+    if #available(iOS 26.0, *) {
+      return false
+    } else {
+      return true
+    }
   }
 
   public override func invalidationContext(


### PR DESCRIPTION
## Summary
- Suppresses preferred-size self-sizing invalidation while `UICollectionView` batch updates are resolving on affected OS versions.
- Keeps the default self-sizing behavior on iOS 26 and newer.
- Reduces the recursive visible-cell update loop seen with SwiftUI-hosted variable-height cells during structural updates.

## Root Cause
UIKit can ask visible cells from both the pre-update and post-update snapshots for preferred sizes while a collection-view batch update is resolving. On affected OS versions, starting another self-sizing invalidation in that window can recurse through visible-cell updates before either snapshot settles.

## Validation
- iOS 17.5 Simulator, Release, `MessagingUIDevelopment --tiled-crash-repro`: completed `cycle 1,000`; no new `.ips` crash report.
- iOS 26.5 Simulator, Release, `MessagingUIDevelopment --tiled-crash-repro`: completed `cycle 1,000`; no new `.ips` crash report.

Note: the local repro harness used for validation is not included in this PR.